### PR TITLE
Fix indexing issue for passive joints before active joints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ scripts/*test*
 *.hdf5
 *.log
 *.dot
+farms_amphibious.egg-info/
+*amd64.pxd

--- a/farms_amphibious/control/amphibious.py
+++ b/farms_amphibious/control/amphibious.py
@@ -111,6 +111,7 @@ class JointMuscleController(AnimatController):
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
     ):
+        joint_names = animat_options.sensor.joints_names()
         joints_control_names = animat_options.control.joints_names()
         joints_control_types: Dict[str, List[ControlType]] = {
             motor.joint_name: ControlType.from_string_list(motor.control_types)
@@ -139,7 +140,7 @@ class JointMuscleController(AnimatController):
         # joints
         self.joints_map: JointsMap = JointsMap(
             joints=self.joints_names,
-            joints_names=joints_control_names,
+            joints_names=joint_names,
             animat_options=animat_options,
         )
 

--- a/farms_amphibious/control/amphibious.py
+++ b/farms_amphibious/control/amphibious.py
@@ -111,7 +111,6 @@ class JointMuscleController(AnimatController):
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
     ):
-        joint_names = animat_options.sensor.joints_names()
         joints_control_names = animat_options.control.joints_names()
         joints_control_types: Dict[str, List[ControlType]] = {
             motor.joint_name: ControlType.from_string_list(motor.control_types)
@@ -140,7 +139,7 @@ class JointMuscleController(AnimatController):
         # joints
         self.joints_map: JointsMap = JointsMap(
             joints=self.joints_names,
-            joints_names=joint_names,
+            joints_sensors_names=self.animat_data.sensors.joints.names,
             animat_options=animat_options,
         )
 
@@ -544,16 +543,15 @@ class JointsMap:
     def __init__(
             self,
             joints: Tuple[List[str]],
-            joints_names: List[str],
+            joints_sensors_names: list[str],
             animat_options: AmphibiousOptions,
     ):
         super().__init__()
         control_types = list(ControlType)
-        self.names = np.array(joints_names)
         self.indices = [  # Indices in animat data for specific control type
             np.array([
                 joint_i
-                for joint_i, joint in enumerate(joints_names)
+                for joint_i, joint in enumerate(joints_sensors_names)
                 if joint in joints[control_type]
             ])
             for control_type in control_types
@@ -564,7 +562,7 @@ class JointsMap:
         }
         self.transform_gain = np.array([
             transform_gains[joint]
-            for joint in joints_names
+            for joint in joints_sensors_names
         ])
         transform_bias = {
             motor.joint_name: motor.transform.bias
@@ -572,7 +570,7 @@ class JointsMap:
         }
         self.transform_bias = np.array([
             transform_bias[joint]
-            for joint in joints_names
+            for joint in joints_sensors_names
         ])
 
 

--- a/farms_amphibious/control/amphibious.py
+++ b/farms_amphibious/control/amphibious.py
@@ -111,7 +111,7 @@ class JointMuscleController(AnimatController):
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
     ):
-        joint_names = animat_options.sensor.joints_names()
+        joint_names = animat_options.morphology.joints_names()
         joints_control_names = animat_options.control.joints_names()
         joints_control_types: Dict[str, List[ControlType]] = {
             motor.joint_name: ControlType.from_string_list(motor.control_types)

--- a/farms_amphibious/control/amphibious.py
+++ b/farms_amphibious/control/amphibious.py
@@ -107,23 +107,23 @@ class JointMuscleController(AnimatController):
 
     def __init__(
             self,
-            joints_names: List[str],
             animat_options: AmphibiousOptions,
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
     ):
+        joints_control_names = animat_options.control.joints_names()
         joints_control_types: Dict[str, List[ControlType]] = {
             motor.joint_name: ControlType.from_string_list(motor.control_types)
             for motor in animat_options.control.motors
         }
         super().__init__(
             joints_names=AnimatController.joints_from_control_types(
-                joints_names=joints_names,
+                joints_names=joints_control_names,
                 joints_control_types=joints_control_types,
             ),
             muscles_names=[],
             max_torques=AnimatController.max_torques_from_control_types(
-                joints_names=joints_names,
+                joints_names=joints_control_names,
                 max_torques={
                     motor.joint_name: motor.limits_torque[1]
                     for motor in animat_options.control.motors
@@ -139,7 +139,7 @@ class JointMuscleController(AnimatController):
         # joints
         self.joints_map: JointsMap = JointsMap(
             joints=self.joints_names,
-            joints_names=joints_names,
+            joints_names=joints_control_names,
             animat_options=animat_options,
         )
 
@@ -151,11 +151,7 @@ class JointMuscleController(AnimatController):
         self.equations: Tuple[List[Callable]] = [[], [], []]
 
         # Muscles
-        self.muscle_map: MusclesMap = MusclesMap(
-            joints=joints_names,
-            animat_options=animat_options,
-            animat_data=animat_data,
-        )
+        self.muscle_maps: dict[str, MusclesMap] = {}
 
         # Network to joints interface
         self.network2joints = {}
@@ -166,28 +162,34 @@ class JointMuscleController(AnimatController):
             if torque_equation not in self.equations_dict.values():
                 continue
 
-            joints_indices = np.array([
-                motor_i
-                for motor_i, motor in enumerate(animat_options.control.motors)
+            muscles_joints: list[str] = [
+                motor.joint_name
+                for motor in animat_options.control.motors
                 if motor.equation == torque_equation
+            ]
+            muscles_joints_indices = np.array([
+                self.animat_data.sensors.joints.names.index(joint_name)
+                for joint_name in muscles_joints
             ], dtype=np.uintc)
-            joints_names = np.array(
-                self.animat_data.sensors.joints.names,
-                dtype=object,
-            )[joints_indices].tolist()
+            self.muscle_maps[torque_equation] = MusclesMap(
+                joints=muscles_joints,
+                animat_options=animat_options,
+                animat_data=animat_data,
+            )
 
             self.equations[ControlType.TORQUE] += [{
                 'ekeberg_muscle': self.ekeberg_muscle,
                 'ekeberg_muscle_explicit': self.ekeberg_muscle_explicit,
             }[torque_equation]]
 
+            muscle_map = self.muscle_maps[torque_equation]
             self.network2joints[torque_equation] = EkebergMuscleCy(
-                joints_names=joints_names,
+                joints_names=muscles_joints,
                 joints_data=self.animat_data.sensors.joints,
-                indices=joints_indices,
+                indices=muscles_joints_indices,
                 state=self.animat_data.state,
-                parameters=np.array(self.muscle_map.arrays, dtype=np.double),
-                osc_indices=np.array(self.muscle_map.osc_indices, dtype=np.uintc),
+                parameters=np.array(muscle_map.arrays, dtype=np.double),
+                osc_indices=np.array(muscle_map.osc_indices, dtype=np.uintc),
                 gain=np.array(self.joints_map.transform_gain, dtype=np.double),
                 bias=np.array(self.joints_map.transform_bias, dtype=np.double),
             )
@@ -195,18 +197,16 @@ class JointMuscleController(AnimatController):
         # Passive joint control
         if 'passive' in self.equations_dict.values():
 
-            joints_indices = np.array([
-                motor_i
-                for motor_i, motor in enumerate(animat_options.control.motors)
-                if motor.equation == 'passive'
-            ], dtype=np.uintc)
-            joints_names = np.array(
-                self.animat_data.sensors.joints.names,
-                dtype=object,
-            )[joints_indices].tolist()
-
             self.equations[ControlType.TORQUE] += [self.passive]
-
+            passive_joints: list[str] = [
+                motor.joint_name
+                for motor in animat_options.control.motors
+                if motor.equation == 'passive'
+            ]
+            passive_joints_indices = np.array([
+                self.animat_data.sensors.joints.names.index(joint_name)
+                for joint_name in passive_joints
+            ], dtype=np.uintc)
             self.network2joints['passive'] = PassiveJointCy(
                 stiffness_coefficients=np.array([
                     motor.passive.stiffness_coefficient
@@ -223,9 +223,9 @@ class JointMuscleController(AnimatController):
                     for motor in animat_options.control.motors
                     if motor.equation == 'passive'
                 ], dtype=np.double),
-                joints_names=joints_names,
+                joints_names=passive_joints,
                 joints_data=self.animat_data.sensors.joints,
-                indices=joints_indices,
+                indices=passive_joints_indices,
                 gain=np.array(self.joints_map.transform_gain, dtype=np.double),
                 bias=np.array(self.joints_map.transform_bias, dtype=np.double),
             )
@@ -355,14 +355,12 @@ class AmphibiousController(JointMuscleController):
 
     def __init__(
             self,
-            joints_names: List[str],
             animat_options: AmphibiousOptions,
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
             drive: DescendingDrive = None,
     ):
         super().__init__(
-            joints_names=joints_names,
             animat_options=animat_options,
             animat_data=animat_data,
             animat_network=animat_network,
@@ -372,23 +370,28 @@ class AmphibiousController(JointMuscleController):
         # Position control
         if 'position' in self.equations_dict.values():
             self.equations[ControlType.POSITION] += [self.positions_network]
-            joints_indices = np.array([
-                motor_i
-                for motor_i, motor in enumerate(animat_options.control.motors)
+            muscles_joints: list[str] = [
+                motor.joint_name
+                for motor in animat_options.control.motors
                 if motor.equation == 'position'
+            ]
+            muscles_joints_indices = np.array([
+                self.animat_data.sensors.joints.names.index(joint_name)
+                for joint_name in muscles_joints
             ], dtype=np.uintc)
-            joints_names = np.array(
-                self.animat_data.sensors.joints.names,
-                dtype=object,
-            )[joints_indices].tolist()
-
+            self.muscle_maps['position'] = MusclesMap(
+                joints=muscles_joints,
+                animat_options=animat_options,
+                animat_data=animat_data,
+            )
+            muscle_map = self.muscle_maps['position']
             self.network2joints['position'] = PositionMuscleCy(
-                joints_names=joints_names,
+                joints_names=muscles_joints,
                 joints_data=self.animat_data.sensors.joints,
-                indices=joints_indices,
+                indices=muscles_joints_indices,
                 state=self.animat_data.state,
-                parameters=np.array(self.muscle_map.arrays, dtype=np.double),
-                osc_indices=np.array(self.muscle_map.osc_indices, dtype=np.uintc),
+                parameters=np.array(muscle_map.arrays, dtype=np.double),
+                osc_indices=np.array(muscle_map.osc_indices, dtype=np.uintc),
                 gain=np.array(self.joints_map.transform_gain, dtype=np.double),
                 bias=np.array(self.joints_map.transform_bias, dtype=np.double),
             )
@@ -396,21 +399,27 @@ class AmphibiousController(JointMuscleController):
         # Phase control
         if 'phase' in self.equations_dict.values():
             self.equations[ControlType.POSITION] += [self.phases_network]
-            joints_indices = np.array([
-                motor_i
-                for motor_i, motor in enumerate(animat_options.control.motors)
+            muscles_joints: list[str] = [
+                motor.joint_name
+                for motor in animat_options.control.motors
                 if motor.equation == 'phase'
+            ]
+            muscles_joints_indices = np.array([
+                self.animat_data.sensors.joints.names.index(joint_name)
+                for joint_name in muscles_joints
             ], dtype=np.uintc)
-            joints_names = np.array(
-                self.animat_data.sensors.joints.names,
-                dtype=object,
-            )[joints_indices].tolist()
+            self.muscle_maps['phase'] = MusclesMap(
+                joints=muscles_joints,
+                animat_options=animat_options,
+                animat_data=animat_data,
+            )
+            muscle_map = self.muscle_maps['phase']
             self.network2joints['phase'] = PositionPhaseCy(
-                joints_names=joints_names,
+                joints_names=muscles_joints,
                 joints_data=self.animat_data.sensors.joints,
-                indices=joints_indices,
+                indices=muscles_joints_indices,
                 state=self.animat_data.state,
-                osc_indices=np.array(self.muscle_map.osc_indices, dtype=np.uintc),
+                osc_indices=np.array(muscle_map.osc_indices, dtype=np.uintc),
                 gain=np.array(self.joints_map.transform_gain, dtype=np.double),
                 bias=np.array(self.joints_map.transform_bias, dtype=np.double),
                 weight=-1e6,
@@ -434,7 +443,6 @@ class AmphibiousController(JointMuscleController):
         """
         del config
         del animat_i
-        joints_names = animat_options.control.joints_names()
         drive = None
         animat_network = NetworkODE(
             data=animat_data,
@@ -463,7 +471,6 @@ class AmphibiousController(JointMuscleController):
                 experiment_options.simulation,
             )
         return cls(
-            joints_names=joints_names,
             animat_options=animat_options,
             animat_data=animat_data,
             animat_network=animat_network,
@@ -573,7 +580,7 @@ class MusclesMap:
 
     def __init__(
             self,
-            joints: Tuple[List[str]],
+            joints: List[str],
             animat_options: AmphibiousOptions,
             animat_data: AmphibiousData,
     ):
@@ -582,10 +589,12 @@ class MusclesMap:
             muscle.joint_name: muscle
             for muscle in animat_options.control.muscles
         }
+        for joint in joints:
+            assert joint in joint_muscle_map, (
+                f"{joint=} not in {joint_muscle_map.keys()=}"
+            )
         muscles = [
             joint_muscle_map[joint]
-            if joint in joint_muscle_map
-            else None
             for joint in joints
         ]
         self.arrays = np.array([
@@ -594,22 +603,16 @@ class MusclesMap:
                 muscle.gamma, muscle.delta,
                 muscle.epsilon,
             ]
-            if muscle is not None
-            else [np.finfo(np.double).max]*5
             for muscle in muscles
         ], dtype=np.double)
         osc_names = animat_data.network.oscillators.names
         self.osc_indices = np.array([
             [
                 osc_names.index(muscle.osc1)
-                if muscle is not None
-                else np.iinfo(np.uintc).max
                 for muscle in muscles
             ],
             [
                 osc_names.index(muscle.osc2)
-                if muscle is not None and muscle.osc2 is not None
-                else np.iinfo(np.uintc).max
                 for muscle in muscles
-             ],
+            ],
         ], dtype=np.uintc)

--- a/farms_amphibious/control/amphibious.py
+++ b/farms_amphibious/control/amphibious.py
@@ -111,7 +111,7 @@ class JointMuscleController(AnimatController):
             animat_data: AmphibiousData,
             animat_network: AnimatNetwork,
     ):
-        joint_names = animat_options.morphology.joints_names()
+        joint_sensor_names = animat_data.sensors.joints.names
         joints_control_names = animat_options.control.joints_names()
         joints_control_types: Dict[str, List[ControlType]] = {
             motor.joint_name: ControlType.from_string_list(motor.control_types)
@@ -140,7 +140,7 @@ class JointMuscleController(AnimatController):
         # joints
         self.joints_map: JointsMap = JointsMap(
             joints=self.joints_names,
-            joints_names=joint_names,
+            joints_names=joint_sensor_names,
             animat_options=animat_options,
         )
 

--- a/farms_amphibious/control/ekeberg.pxd
+++ b/farms_amphibious/control/ekeberg.pxd
@@ -1,5 +1,6 @@
 """Ekeberg muscle model"""
 
+include 'types.pxd'
 cimport numpy as np
 import numpy as np
 from .muscle_cy cimport JointsMusclesCy
@@ -8,4 +9,7 @@ from .muscle_cy cimport JointsMusclesCy
 cdef class EkebergMuscleCy(JointsMusclesCy):
     """Ekeberg muscle model"""
     cdef public np.ndarray joints_offsets
+    cdef public np.ndarray activations
+    cpdef void update_activations(self, unsigned int iteration)
+    cpdef void update_offsets(self, unsigned int iteration)
     cpdef void step(self, unsigned int iteration)

--- a/farms_amphibious/control/ekeberg.pyx
+++ b/farms_amphibious/control/ekeberg.pyx
@@ -79,12 +79,12 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
 
             # Torques
             active_torque = (
-                self.parameters[joint_data_i][ALPHA]
+                self.parameters[muscle_i][ALPHA]
                 *neural_diff
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             stiffness_intermediate = (
-                self.parameters[joint_data_i][BETA]
+                self.parameters[muscle_i][BETA]
                 *m_delta_phi
             )
             active_stiffness = (
@@ -93,16 +93,16 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             passive_stiffness = (
-                self.parameters[joint_data_i][GAMMA]
+                self.parameters[muscle_i][GAMMA]
                 *stiffness_intermediate
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             damping = -(
-                self.parameters[joint_data_i][DELTA]
+                self.parameters[muscle_i][DELTA]
                 *velocities[joint_data_i]
             )
             friction = -(
-                self.parameters[joint_data_i][EPSILON]
+                self.parameters[muscle_i][EPSILON]
                 *sign(velocities[joint_data_i])
             )
 

--- a/farms_amphibious/control/ekeberg.pyx
+++ b/farms_amphibious/control/ekeberg.pyx
@@ -1,6 +1,5 @@
 """Ekeberg muscle model"""
 
-include 'types.pxd'
 include 'sensor_convention.pxd'
 cimport numpy as np
 import numpy as np
@@ -28,7 +27,16 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.activations = np.zeros(self.n_joints, dtype=np.double)
         self.joints_offsets = np.zeros(self.n_joints, dtype=np.double)
+
+    cpdef void update_activations(self, unsigned int iteration):
+        """Update offsets"""
+        self.activations = self.state.outputs(iteration)
+
+    cpdef void update_offsets(self, unsigned int iteration):
+        """Update offsets"""
+        self.joints_offsets = np.array(self.state.offsets(iteration))
 
     cpdef void step(self, unsigned int iteration):
         """Step"""
@@ -36,24 +44,35 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
         cdef DTYPE neural_diff, neural_sum
         cdef DTYPE active_torque, stiffness_intermediate
         cdef DTYPE active_stiffness, passive_stiffness, damping, friction
-        cdef np.ndarray neural_activity = self.state.outputs(iteration)
-        cdef DTYPEv1 offsets = self.state.offsets(iteration)
         cdef DTYPEv1 positions = self.joints_data.positions(iteration)
         cdef DTYPEv1 velocities = self.joints_data.velocities(iteration)
+
+        # Update
+        self.update_activations(iteration)
+        self.update_offsets(iteration)
 
         # For each muscle
         for muscle_i in range(self.n_joints):
 
+            # Muscle indices map - The indices relate to the list of motors
+            # defined in the animat config, with only the motors using the
+            # Ekeberg muscle model being present. The given indices, in the
+            # order of muscles, will provide the mapping to the indices of the
+            # joints sensors data. See the amphibious controller initialisation
+            # AmphibiousController.__init__ for the declaration.
             joint_data_i = self.indices[muscle_i]
 
-            # Offsets
-            self.joints_offsets[muscle_i] = offsets[muscle_i]
+            # Oscillator indices - The indices relate to the list
+            # animat_data.network.oscillators.names defined in the animat
+            # config. The first index accesses the first or second input, while
+            # the second index accesses the index for the neural activity. Refer
+            # to MusclesMap.__init__ for the declaration.
+            osc_0 = self.osc_indices[0][muscle_i]
+            osc_1 = self.osc_indices[1][muscle_i]
 
             # Data
-            osc_0 = self.osc_indices[0][joint_data_i]
-            osc_1 = self.osc_indices[1][joint_data_i]
-            neural_diff = neural_activity[osc_1] - neural_activity[osc_0]
-            neural_sum = neural_activity[osc_0] + neural_activity[osc_1]
+            neural_diff = self.activations[osc_1] - self.activations[osc_0]
+            neural_sum = self.activations[osc_0] + self.activations[osc_1]
             m_delta_phi = self.joints_offsets[muscle_i] - (
                 positions[joint_data_i] - self.transform_bias[joint_data_i]
             )/self.transform_gain[joint_data_i]  # Amphibious convention space

--- a/farms_amphibious/control/ekeberg.pyx
+++ b/farms_amphibious/control/ekeberg.pyx
@@ -50,8 +50,8 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
             self.joints_offsets[muscle_i] = offsets[muscle_i]
 
             # Data
-            osc_0 = self.osc_indices[0][muscle_i]
-            osc_1 = self.osc_indices[1][muscle_i]
+            osc_0 = self.osc_indices[0][joint_data_i]
+            osc_1 = self.osc_indices[1][joint_data_i]
             neural_diff = neural_activity[osc_1] - neural_activity[osc_0]
             neural_sum = neural_activity[osc_0] + neural_activity[osc_1]
             m_delta_phi = self.joints_offsets[muscle_i] - (
@@ -60,12 +60,12 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
 
             # Torques
             active_torque = (
-                self.parameters[muscle_i][ALPHA]
+                self.parameters[joint_data_i][ALPHA]
                 *neural_diff
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             stiffness_intermediate = (
-                self.parameters[muscle_i][BETA]
+                self.parameters[joint_data_i][BETA]
                 *m_delta_phi
             )
             active_stiffness = (
@@ -74,16 +74,16 @@ cdef class EkebergMuscleCy(JointsMusclesCy):
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             passive_stiffness = (
-                self.parameters[muscle_i][GAMMA]
+                self.parameters[joint_data_i][GAMMA]
                 *stiffness_intermediate
                 *self.transform_gain[joint_data_i]  # SDF space
             )
             damping = -(
-                self.parameters[muscle_i][DELTA]
+                self.parameters[joint_data_i][DELTA]
                 *velocities[joint_data_i]
             )
             friction = -(
-                self.parameters[muscle_i][EPSILON]
+                self.parameters[joint_data_i][EPSILON]
                 *sign(velocities[joint_data_i])
             )
 

--- a/farms_amphibious/control/passive_cy.pyx
+++ b/farms_amphibious/control/passive_cy.pyx
@@ -39,7 +39,12 @@ cdef class PassiveJointCy(JointsControlCy):
         # For each muscle
         for joint_i in range(self.n_joints):
 
-            # Joint index
+            # Joint sensor index map - The indices relate to the list of motors
+            # defined in the animat config, with only the motors using the
+            # passive model being present. The given indices, in the order of
+            # the passive joints provided, will provide the mapping to the
+            # indices of the joints sensors data. See the amphibious controller
+            # initialisation JointMuscleController.__init__ for the declaration.
             joint_data_i = self.indices[joint_i]
 
             # Torques
@@ -64,7 +69,7 @@ cdef class PassiveJointCy(JointsControlCy):
             self.joints_data.array[iteration, joint_data_i, JOINT_TORQUE_FRICTION] = friction
 
     cpdef np.ndarray stiffness(self, unsigned int iteration):
-        """Torques"""
+        """Stiffness"""
         return get_joints_data(
             iteration=iteration,
             joints_data=self.joints_data,
@@ -74,7 +79,7 @@ cdef class PassiveJointCy(JointsControlCy):
         )
 
     cpdef np.ndarray damping(self, unsigned int iteration):
-        """Torques"""
+        """Damping"""
         return get_joints_data(
             iteration=iteration,
             joints_data=self.joints_data,
@@ -84,7 +89,7 @@ cdef class PassiveJointCy(JointsControlCy):
         )
 
     cpdef np.ndarray friction(self, unsigned int iteration):
-        """Torques"""
+        """Friction"""
         return get_joints_data(
             iteration=iteration,
             joints_data=self.joints_data,

--- a/farms_amphibious/model/options.py
+++ b/farms_amphibious/model/options.py
@@ -209,12 +209,13 @@ class AmphibiousOptions(AnimatOptions):
 
     def state_init(self):
         """Initial states"""
+        active_joints = [motor.joint_name for motor in self.control.motors if motor.equation != 'passive']
         return [
             osc.initial_phase for osc in self.control.network.oscillators
         ] + [
             osc.initial_amplitude for osc in self.control.network.oscillators
         ] + [
-            joint.initial[0] for joint in self.morphology.joints
+            joint.initial[0] for joint in self.morphology.joints if joint.name in active_joints
         ]
 
 

--- a/farms_amphibious/model/options.py
+++ b/farms_amphibious/model/options.py
@@ -209,13 +209,20 @@ class AmphibiousOptions(AnimatOptions):
 
     def state_init(self):
         """Initial states"""
-        active_joints = [motor.joint_name for motor in self.control.motors if motor.equation != 'passive']
+        active_joints = [
+            muscle.joint_name
+            for muscle in self.control.muscles
+        ]
         return [
-            osc.initial_phase for osc in self.control.network.oscillators
+            osc.initial_phase
+            for osc in self.control.network.oscillators
         ] + [
-            osc.initial_amplitude for osc in self.control.network.oscillators
+            osc.initial_amplitude
+            for osc in self.control.network.oscillators
         ] + [
-            joint.initial[0] for joint in self.morphology.joints if joint.name in active_joints
+            joint.initial[0]
+            for joint in self.morphology.joints
+            if joint.name in active_joints
         ]
 
 


### PR DESCRIPTION
Fix data indexing issue when joints are not ordered active joints before passive joints.

Background:
1.JointControlArrayCy has a parameter space inferred from control.motors (active ones with transform offsets) (Musclemap)
2.The indexing of JointControlArrayCy was inferred from sensor.joints.
3.Joints ODE has a state space inferred morphology.joints

Fix: Remove passive joints from ODE to improve performance. Change the indexing of [parameter] of Ekeberg muscles to use the indexing it accpets (from sensor.joints)
TODO: Optimally it should use the indexing from control.motors.

Note: Current code structure implicitly enforced that **control.muscles**, **sensor.joints** and **control.motors** must have same joints included in the same order. Active motors in the former two must be in the same order of active joints in **morphology.joints**. To release the constraint a mapping between these variables is needed at animat load time. (To improve)

