### PR TITLE
[FIX] add missing pylog in network.py used during ODE warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ scripts/*test*
 *.hdf5
 *.log
 *.dot
+farms_amphibious.egg-info
+*amd64.pxd

--- a/farms_amphibious/control/network.py
+++ b/farms_amphibious/control/network.py
@@ -8,6 +8,7 @@ from scipy import integrate
 from scipy.integrate._ode import ode as ODE
 
 from farms_core.model.data import AnimatData
+from farms_core import pylog
 
 from .ode import ode_oscillators_sparse
 


### PR DESCRIPTION
Add missing pylog import in network.py (triggered when ODE fails)