### PR TITLE
[KINEMATICS] Fix kinematics controller in v0.2 where amphibious.py is…

### DIFF
--- a/farms_amphibious/control/kinematics.py
+++ b/farms_amphibious/control/kinematics.py
@@ -2,11 +2,13 @@
 
 import numpy as np
 from scipy.interpolate import interp1d
+from pathlib import Path
+
+from farms_core.experiment.options import ExperimentOptions
+from farms_core.model.control import AnimatController, ControlType
 from farms_core.model.data import AnimatData
 from farms_core.model.options import AnimatOptions
-from farms_core.model.control import AnimatController, ControlType
-from farms_core.experiment.options import ExperimentOptions
-
+from farms_core import pylog
 
 def kinematics_interpolation(
         kin_times,
@@ -16,6 +18,7 @@ def kinematics_interpolation(
 ):
     """Kinematics interpolations"""
     simulation_duration = timestep*n_iterations
+    pylog.info(f'KINEMATICS: Loaded kinematics data for {max(kin_times)} seconds, Simulation duration {simulation_duration} seconds.')
     sim_times = np.arange(0, simulation_duration, timestep)
     assert len(kin_times) == kinematics.shape[0], (
         f'{len(kin_times)=} != {kinematics.shape[0]=}'
@@ -33,6 +36,7 @@ class KinematicsController(AnimatController):
     def __init__(
             self,
             joints_names,
+            muscles_names,
             kinematics,
             sampling,
             timestep,
@@ -45,6 +49,7 @@ class KinematicsController(AnimatController):
             degrees=False,
             init_time=0,
             end_time=0,
+            **kwargs,
     ):
         super().__init__(
             joints_names=joints_names,
@@ -52,6 +57,10 @@ class KinematicsController(AnimatController):
             muscles_names=[],
         )
 
+        kinematics_v = kwargs.pop('kinematics_v', None)
+        if kinematics_v is not None:
+            assert kinematics.shape[0] == kinematics_v.shape[0]
+            assert kinematics.shape[1] == kinematics_v.shape[1]
         # Time vector
         if time_index is not None:
             time_vector = kinematics[:, time_index]
@@ -63,10 +72,14 @@ class KinematicsController(AnimatController):
         # Indices
         if indices:
             kinematics = kinematics[:, indices]
+            if kinematics_v is not None:
+                kinematics_v = kinematics_v[:, indices]
         elif time_index:
             mask = np.ones(kinematics.shape, dtype=bool)
             mask[:, time_index] = False
             kinematics = kinematics[mask]
+            if kinematics_v is not None:
+                kinematics_v = kinematics_v[mask]
         assert kinematics.shape[1] == len(joints_names[ControlType.POSITION]), (
             f'Expected {len(joints_names[ControlType.POSITION])} joints,'
             f' but got {kinematics.shape[1]} (shape={kinematics.shape}'
@@ -76,11 +89,13 @@ class KinematicsController(AnimatController):
         # Converting to radians
         if degrees:
             kinematics = np.deg2rad(kinematics)
-
+            if kinematics_v is not None:
+                kinematics_v = np.deg2rad(kinematics_v)
         # Invert motors
         if invert_motors:
             kinematics *= -1
-
+            if kinematics_v is not None:
+                kinematics_v *= -1
         # Add initial time
         if init_time > 0:
             kinematics = np.insert(
@@ -93,6 +108,17 @@ class KinematicsController(AnimatController):
                 ),
                 axis=0,
             )
+            if kinematics_v is not None:
+                kinematics_v = np.insert(
+                    arr=kinematics_v,
+                    obj=0,
+                    values=np.repeat(
+                        a=[kinematics_v[0, :]],
+                        repeats=int(init_time/sampling)+1,
+                        axis=0,
+                    ),
+                    axis=0,
+                )
             time_vector += init_time
             time_vector = np.insert(
                 time_vector,
@@ -116,6 +142,17 @@ class KinematicsController(AnimatController):
                 ),
                 axis=0,
             )
+            if kinematics_v is not None:
+                kinematics_v = np.insert(
+                    arr=kinematics_v,
+                    obj=kinematics_v.shape[0],
+                    values=np.repeat(
+                        a=[kinematics_v[-1, :]],
+                        repeats=int(end_time/sampling)+1,
+                        axis=0,
+                    ),
+                    axis=0,
+                )
             if time_vector is not None:
                 time_vector = np.insert(
                     arr=time_vector,
@@ -133,8 +170,15 @@ class KinematicsController(AnimatController):
             timestep=timestep,
             n_iterations=n_iterations,
         )
-        self.animat_data = animat_data
+        if kinematics_v is not None:
+            self.kinematics_v = kinematics_interpolation(
+                kin_times=time_vector,
+                kinematics=kinematics_v,
+                timestep=timestep,
+                n_iterations=n_iterations,
+            )
 
+        self.animat_data = animat_data
     @classmethod
     def from_options(
             cls,
@@ -144,7 +188,15 @@ class KinematicsController(AnimatController):
             animat_data: AnimatData,
             animat_options: AnimatOptions,
     ):
-        """From options"""
+        """From options
+
+        animat_options = experiment_options.animats[animat_i]
+
+        """
+        
+        del config
+        del animat_i
+        sim_options = experiment_options.simulation
         joints_names = animat_options.control.joints_names()
         joints_control_types = {
             motor.joint_name: ControlType.from_string_list(
@@ -165,25 +217,56 @@ class KinematicsController(AnimatController):
             max_torques=max_torques,
             joints_control_types=joints_control_types,
         )
-        return KinematicsController(
+        if not Path(animat_options.control.kinematics_file).is_file():
+            raise FileNotFoundError(
+                f"{animat_options.control.kinematics_file} is not a file"
+            )
+        
+        kinematics_position_target = np.genfromtxt(
+                animat_options.control.kinematics_file,
+                delimiter=',',
+        )
+        
+        if 'kinematics_v_file' in animat_options.control:
+            if not Path(animat_options.control.kinematics_v_file).is_file():
+                raise FileNotFoundError(
+                    f"{animat_options.control.kinematics_v_file} is not a file"
+                )
+            kinematics_velocity_target = np.genfromtxt(
+                    animat_options.control.kinematics_v_file,
+                    delimiter=',',
+            )
+        else:
+            kinematics_velocity_target = None
+
+        return cls(
             joints_names=joints_names_per_type,
-            kinematics=np.genfromtxt(config['kinematics_file'], delimiter=','),
-            sampling=config['kinematics_sampling'],
-            indices=config['kinematics_indices'],
-            time_index=config['kinematics_time_index'],
-            invert_motors=config['kinematics_invert'],
-            degrees=config['kinematics_degrees'],
-            timestep=experiment_options.simulation.physics.timestep,
-            n_iterations=experiment_options.simulation.runtime.n_iterations,
+            muscles_names=[], # no muscles in kinematics controller, remove in the future?
+            kinematics=kinematics_position_target,
+            kinematics_v=kinematics_velocity_target,
+            sampling=animat_options.control.kinematics_sampling,
+            timestep=sim_options.physics.timestep,
+            n_iterations=sim_options.runtime.n_iterations,
             animat_data=animat_data,
             max_torques=max_torques_per_type,
-            init_time=config['kinematics_start'],
-            end_time=config['kinematics_end'],
+            invert_motors=animat_options.control.kinematics_invert,
+            indices=animat_options.control.kinematics_indices,
+            time_index=animat_options.control.kinematics_time_index,
+            degrees=animat_options.control.kinematics_degrees,
+            init_time=animat_options.control.kinematics_start,
+            end_time=animat_options.control.kinematics_end,
         )
+        
 
     def positions(self, iteration, time, timestep):
         """Postions"""
         return dict(zip(
             self.joints_names[ControlType.POSITION],
             self.kinematics[iteration],
+        ))
+
+    def velocities(self, iteration, time, timestep):
+        return dict(zip(
+            self.joints_names[ControlType.VELOCITY],
+            self.kinematics_v[iteration],
         ))

--- a/farms_amphibious/data/data.py
+++ b/farms_amphibious/data/data.py
@@ -266,7 +266,6 @@ class AmphibiousKinematicsData(AnimatData):
     ):
         """From animat and simulation options"""
         return cls(
-            timestep=simulation_options.timestep,
             sensors=SensorsData.from_options(
                 animat_options=animat_options,
                 simulation_options=simulation_options,

--- a/farms_amphibious/model/options.py
+++ b/farms_amphibious/model/options.py
@@ -894,10 +894,10 @@ class KinematicsControlOptions(ControlOptions):
                 AmphibiousMotorOptions(**motor)
                 for motor in kwargs.pop('motors')
             ],
-            muscles=kwargs.pop('muscles', []),
         )
         self.hill_muscles = kwargs.pop('hill_muscles', [])
         self.kinematics_file = kwargs.pop('kinematics_file')
+        self.kinematics_v_file = kwargs.pop('kinematics_v_file',None)
         self.kinematics_sampling = kwargs.pop('kinematics_sampling')
         self.kinematics_indices = kwargs.pop('kinematics_indices')
         self.kinematics_time_index = kwargs.pop('kinematics_time_index')

--- a/farms_amphibious/model/options.py
+++ b/farms_amphibious/model/options.py
@@ -889,6 +889,10 @@ class KinematicsControlOptions(ControlOptions):
 
     def __init__(self, **kwargs):
         super().__init__(
+            controller_loader=kwargs.pop(
+                'controller_loader',
+                'farms_amphibious.control.amphibious.KinematicsController',
+            ),
             sensors=(AmphibiousSensorsOptions(**kwargs.pop('sensors'))),
             motors=[
                 AmphibiousMotorOptions(**motor)


### PR DESCRIPTION
In old farms:
controller is initilaized in amphibious.py
animat_controller = get_amphibious_controller()
get_amphibious_controller handles if controller is amphibious or kinematics
and animat_controller is directly passed into run_simulation() afterwards

In new farms:
The controller initialization is handled in ExperimentTask with experiment_options (referring to a config file)
get_amphibious_controller() is no longer called.

Controller needs to be initialized with from_options() in ExperimentTask.extract_extensions instead of get_amphibious_controller()
from_options() now is only designed for amphibious controler.
The handling of kinematics controller locates inside get_amphibious_controller() is never called in the new logic.

In the new logic controller initiates from from_options()

KinematicsController has no from_options override

Also KinematicsController is an instance of AnimatController, which now always assumes the necessary use of muscles.

This patch updates KinematicsController to make it compatible with farms v0.2 again and allows for not using muscles in KinematicsController.
(The redundant codes now in amphibious.py regarding kinematics controller are kept now but should be removed in the future)